### PR TITLE
Pankuzu template

### DIFF
--- a/Config/Migration/1492400469_menu_new_template_add.php
+++ b/Config/Migration/1492400469_menu_new_template_add.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Minorテンプレートの働きを「配下ページのみ表示」に変更することにより
+ * これでにminorテンプレートを設定していたところをmajorにするように修正 Migration
+ *
+ * @author AllCreator <info@allcreator.net>
+ * @link http://www.netcommons.org NetCommons Project
+ * @license http://www.netcommons.org/license.txt NetCommons License
+ * @copyright Copyright 2014, NetCommons Project
+ */
+
+App::uses('NetCommonsMigration', 'NetCommons.Config/Migration');
+App::uses('MenuFrameSetting', 'Menus.Model');
+
+/**
+ * MenuFrameSettingのminorを設定していたところはMajorにする修正 Migration
+ *
+ * @author AllCreator <info@allcreator.net>
+ * @package NetCommons\Menus\Config\Migration
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ */
+class MenuNewTemplateAdd extends NetCommonsMigration {
+
+/**
+ * Migration description
+ *
+ * @var string
+ */
+	public $description = 'menu_new_template_add';
+
+/**
+ * Actions to be performed
+ *
+ * @var array $migration
+ */
+	public $migration = array(
+		'up' => array(
+		),
+		'down' => array(
+		),
+	);
+
+/**
+ * Before migration callback
+ *
+ * @param string $direction Direction of migration process (up or down)
+ * @return bool Should process continue
+ */
+	public function before($direction) {
+		return true;
+	}
+
+/**
+ * After migration callback
+ *
+ * @param string $direction Direction of migration process (up or down)
+ * @return bool Should process continue
+ */
+	public function after($direction) {
+		if ($direction === 'up') {
+			$MenuFrameSetting = $this->generateModel('MenuFrameSetting');
+			$update = array(
+				'MenuFrameSetting.display_type' => "'major'"
+			);
+			$conditions = array(
+				'MenuFrameSetting.display_type' => 'minor'
+			);
+			if (! $MenuFrameSetting->updateAll($update, $conditions)) {
+				return false;
+			}
+		}
+		return true;
+	}
+}

--- a/Controller/MenusController.php
+++ b/Controller/MenusController.php
@@ -97,6 +97,10 @@ class MenusController extends MenusAppController {
 		}
 		$defaultHidden = in_array($menuFrameSetting['MenuFrameSetting']['display_type'], $options, true);
 		$this->set('defaultHidden', $defaultHidden);
+		if ($menuFrameSetting['MenuFrameSetting']['display_type']
+			== MenuFrameSetting::DISPLAY_TYPE_PATH) {
+			$this->set('glyphiconHiddenHidden', true);
+		}
 	}
 
 }

--- a/Locale/eng/LC_MESSAGES/menus.po
+++ b/Locale/eng/LC_MESSAGES/menus.po
@@ -45,3 +45,5 @@ msgstr ""
 msgid "Folder type"
 msgstr ""
 
+msgid "Topic path"
+msgstr ""

--- a/Locale/jpn/LC_MESSAGES/menus.po
+++ b/Locale/jpn/LC_MESSAGES/menus.po
@@ -53,3 +53,6 @@ msgstr "当ページを表示"
 
 msgid "Show lower layer page clicked"
 msgstr "下層ページを表示"
+
+msgid "Topic path"
+msgstr "パンくず"

--- a/Locale/menus.pot
+++ b/Locale/menus.pot
@@ -45,3 +45,5 @@ msgstr ""
 msgid "Folder type"
 msgstr ""
 
+msgid "Topic path"
+msgstr ""

--- a/Model/MenuFrameSetting.php
+++ b/Model/MenuFrameSetting.php
@@ -57,6 +57,13 @@ class MenuFrameSetting extends MenusAppModel {
 	const DISPLAY_TYPE_MAIN = 'main';
 
 /**
+ * パンくずタイプ定数
+ *
+ * @var string
+ */
+	const DISPLAY_TYPE_PATH = 'topic_path';
+
+/**
  * メニューのリスト
  *
  * View/Elements/Menusのディレクトリを__constructでセットする
@@ -103,8 +110,17 @@ class MenuFrameSetting extends MenusAppModel {
 				case self::DISPLAY_TYPE_RIGHT:
 					$label = __d('menus', 'Right type');
 					break;
-				default:
+				case self::DISPLAY_TYPE_PATH:
+					$label = __d('menus', 'Topic path');
+					break;
+				case self::DISPLAY_TYPE_MAIN:
 					$label = __d('menus', 'Main type');
+					break;
+				default:
+					// defaultはdir名をそのまま出します。そうしておくと、カスタムをかける場合
+					// 新規テンプレートを増やしやすいです
+					$label = __d('menus', $dir);
+					break;
 			}
 			$this->menuTypes[$dir] = $label;
 		}

--- a/Test/Case/View/Elements/Menus/minor/IndexTest.php
+++ b/Test/Case/View/Elements/Menus/minor/IndexTest.php
@@ -89,12 +89,12 @@ class MenusViewElementsMenusMinorIndexTest extends NetCommonsControllerTestCase 
 		$pattern = '<div class="list-group">';
 		$pattern .= $this->__getPattern($frameId, '5', '/test2', '', 'サブルーム１');
 		$pattern .= '<\/div>';
-		$this->assertRegExp('/' . $pattern . '/', $this->view);
+		$this->assertNotRegExp('/' . $pattern . '/', $this->view);
 
 		$pattern = '<div class="list-group">';
 		$pattern .= $this->__getPattern($frameId, '6', '/test3', '', 'サブルーム２');
 		$pattern .= '<\/div>';
-		$this->assertRegExp('/' . $pattern . '/', $this->view);
+		$this->assertNotRegExp('/' . $pattern . '/', $this->view);
 	}
 
 /**

--- a/View/Elements/Menus/minor/index.ctp
+++ b/View/Elements/Menus/minor/index.ctp
@@ -10,16 +10,23 @@
  */
 ?>
 
-<?php foreach ($menuFrameRooms as $menuFrameRoom) : ?>
-	<?php
-		echo '<div class="list-group">';
-		foreach (Hash::get($menus, $menuFrameRoom['Room']['id']) as $menu) {
-			$nest = substr_count(Hash::get($pageTreeList, $menu['Page']['id']), Page::$treeParser);
-			if ($nest === 0) {
-				echo $this->Menu->render($menu);
-				echo $this->Menu->renderChild($menu['Page']['room_id'], $menu['Page']['id']);
+<?php
+	echo '<div class="list-group">';
+	$rootId = Current::read('Page.root_id');
+	if ($rootId == 1) {
+		$checkNest = 1;
+	} else {
+		$checkNest = 0;
+	}
+	foreach ($parentPages as $menu) {
+		$nest = substr_count(Hash::get($pageTreeList, $menu['Page']['id']), Page::$treeParser);
+		if ($nest === $checkNest) {
+			$targetMenu = Hash::extract($menus, '{n}.' . $menu['Page']['id']);
+			if (! empty($targetMenu)) {
+				echo $this->Menu->render($targetMenu[0], false);
+				echo $this->Menu->renderChild($menu['Page']['room_id'], $menu['Page']['id'], false);
 			}
 		}
-		echo '</div>';
-	?>
-<?php endforeach;
+	}
+	echo '</div>';
+

--- a/View/Elements/Menus/topic_path/index.ctp
+++ b/View/Elements/Menus/topic_path/index.ctp
@@ -1,0 +1,24 @@
+<?php
+/**
+ * header index template
+ *
+ * @author      Noriko Arai <arai@nii.ac.jp>
+ * @author      Shohei Nakajima <nakajimashouhei@gmail.com>
+ * @link        http://www.netcommons.org NetCommons Project
+ * @license     http://www.netcommons.org/license.txt NetCommons License
+ * @copyright   Copyright 2014, NetCommons Project
+ */
+?>
+
+<ul class="breadcrumb">
+	<?php
+		foreach ($menuFrameRooms as $menuFrameRoom) {
+			foreach (Hash::get($menus, $menuFrameRoom['Room']['id']) as $menu) {
+				if ($menu['Page']['id'] == Current::read('Page.id')) {
+					echo $this->Menu->renderParent($menu['Page']['room_id'], $menu['Page']['id']);
+				}
+			}
+		}
+	?>
+</ul>
+

--- a/View/Elements/Menus/topic_path/list.ctp
+++ b/View/Elements/Menus/topic_path/list.ctp
@@ -1,0 +1,25 @@
+<?php
+/**
+ * main index template
+ *
+ * @author      Noriko Arai <arai@nii.ac.jp>
+ * @author      Shohei Nakajima <nakajimashouhei@gmail.com>
+ * @link        http://www.netcommons.org NetCommons Project
+ * @license     http://www.netcommons.org/license.txt NetCommons License
+ * @copyright   Copyright 2014, NetCommons Project
+ */
+
+$class = '';
+//$class .= 'list-group-item clearfix';
+//$class .= ' menu-tree-' . $nest;
+if ($isActive) {
+	$class .= ' active';
+}
+$options['options']['class'] = $class;
+
+if (isset($options['title'])) {
+	$title = $options['title'];
+			//'<span class="pull-right">' . $options['icon'] . '</span>';
+
+	echo '<li>' . $this->NetCommonsHtml->link($title, $options['url'], $options['options']) . '</li>';
+}

--- a/webroot/css/style.css
+++ b/webroot/css/style.css
@@ -42,6 +42,18 @@
 	margin-left: 20px;
 }
 
+.breadcrumb .menu-tree-1 ,
+.breadcrumb .menu-tree-2 ,
+.breadcrumb .menu-tree-3 ,
+.breadcrumb .menu-tree-4 ,
+.breadcrumb .menu-tree-5 ,
+.breadcrumb .menu-tree-6 ,
+.breadcrumb .menu-tree-7 ,
+.breadcrumb .menu-tree-8 ,
+.breadcrumb .menu-tree-9 {
+	margin-left: 0px;
+}
+
 .menu-list-item {
 	padding-top: 6px;
 	padding-bottom: 6px;


### PR DESCRIPTION
パンくずのテンプレートを追加しています。
「右タイプ（minor）」のテンプレートの動きを、配下ページのみ表示のものにしています。
一緒に名前を変えるべきだったかもしれませんが。とりあえず名称はそのままにしています。