### PR TITLE
Issue 1371

### DIFF
--- a/Test/Case/View/Elements/Menus/footer/IndexTest.php
+++ b/Test/Case/View/Elements/Menus/footer/IndexTest.php
@@ -66,7 +66,7 @@ class MenusViewElementsMenusFooterIndexTest extends NetCommonsControllerTestCase
 		$frameId = '4';
 		Current::write('Page.id', '4');
 		Current::write('Page.permalink', 'home');
-		Current::write('Page.full_permalink', 'public/home');
+		Current::write('Page.full_permalink', 'home');
 
 		//テスト実行
 		$this->_testGetAction('/test_menus/test_view_elements_menus_footer_index/index?frame_id=' . $frameId,

--- a/Test/Case/View/Elements/Menus/footer/IndexTest.php
+++ b/Test/Case/View/Elements/Menus/footer/IndexTest.php
@@ -66,6 +66,7 @@ class MenusViewElementsMenusFooterIndexTest extends NetCommonsControllerTestCase
 		$frameId = '4';
 		Current::write('Page.id', '4');
 		Current::write('Page.permalink', 'home');
+		Current::write('Page.full_permalink', 'public/home');
 
 		//テスト実行
 		$this->_testGetAction('/test_menus/test_view_elements_menus_footer_index/index?frame_id=' . $frameId,

--- a/Test/Case/View/Elements/Menus/header/IndexTest.php
+++ b/Test/Case/View/Elements/Menus/header/IndexTest.php
@@ -66,7 +66,7 @@ class MenusViewElementsMenusHeaderIndexTest extends NetCommonsControllerTestCase
 		$frameId = '1';
 		Current::write('Page.id', '4');
 		Current::write('Page.permalink', 'home');
-		Current::write('Page.full_permalink', 'public/home');
+		Current::write('Page.full_permalink', 'home');
 
 		//テスト実行
 		$this->_testGetAction('/test_menus/test_view_elements_menus_header_index/index?frame_id=' . $frameId,

--- a/Test/Case/View/Elements/Menus/header/IndexTest.php
+++ b/Test/Case/View/Elements/Menus/header/IndexTest.php
@@ -66,6 +66,7 @@ class MenusViewElementsMenusHeaderIndexTest extends NetCommonsControllerTestCase
 		$frameId = '1';
 		Current::write('Page.id', '4');
 		Current::write('Page.permalink', 'home');
+		Current::write('Page.full_permalink', 'public/home');
 
 		//テスト実行
 		$this->_testGetAction('/test_menus/test_view_elements_menus_header_index/index?frame_id=' . $frameId,

--- a/Test/Case/View/Elements/Menus/major/IndexTest.php
+++ b/Test/Case/View/Elements/Menus/major/IndexTest.php
@@ -66,6 +66,7 @@ class MenusViewElementsMenusMajorIndexTest extends NetCommonsControllerTestCase 
 		$frameId = '2';
 		Current::write('Page.id', '4');
 		Current::write('Page.permalink', 'home');
+		Current::write('Page.full_permalink', 'public/home');
 
 		//テスト実行
 		$this->_testGetAction('/test_menus/test_view_elements_menus_major_index/index?frame_id=' . $frameId,

--- a/Test/Case/View/Elements/Menus/major/IndexTest.php
+++ b/Test/Case/View/Elements/Menus/major/IndexTest.php
@@ -66,7 +66,7 @@ class MenusViewElementsMenusMajorIndexTest extends NetCommonsControllerTestCase 
 		$frameId = '2';
 		Current::write('Page.id', '4');
 		Current::write('Page.permalink', 'home');
-		Current::write('Page.full_permalink', 'public/home');
+		Current::write('Page.full_permalink', 'home');
 
 		//テスト実行
 		$this->_testGetAction('/test_menus/test_view_elements_menus_major_index/index?frame_id=' . $frameId,

--- a/Test/Case/View/Elements/Menus/minor/IndexTest.php
+++ b/Test/Case/View/Elements/Menus/minor/IndexTest.php
@@ -66,7 +66,7 @@ class MenusViewElementsMenusMinorIndexTest extends NetCommonsControllerTestCase 
 		$frameId = '3';
 		Current::write('Page.id', '9');
 		Current::write('Page.permalink', 'page_1');
-		Current::write('Page.full_permalink', 'community/page_1');
+		Current::write('Page.full_permalink', 'page_1');
 
 		//テスト実行
 		$this->_testGetAction('/test_menus/test_view_elements_menus_minor_index/index?frame_id=' . $frameId,

--- a/Test/Case/View/Elements/Menus/minor/IndexTest.php
+++ b/Test/Case/View/Elements/Menus/minor/IndexTest.php
@@ -66,6 +66,7 @@ class MenusViewElementsMenusMinorIndexTest extends NetCommonsControllerTestCase 
 		$frameId = '3';
 		Current::write('Page.id', '9');
 		Current::write('Page.permalink', 'page_1');
+		Current::write('Page.full_permalink', 'community/page_1');
 
 		//テスト実行
 		$this->_testGetAction('/test_menus/test_view_elements_menus_minor_index/index?frame_id=' . $frameId,

--- a/View/Helper/MenuHelper.php
+++ b/View/Helper/MenuHelper.php
@@ -319,7 +319,7 @@ class MenuHelper extends AppHelper {
  * @return bool
  */
 	public function isActive($page) {
-		return Current::read('Page.permalink') === (string)$page['Page']['permalink'];
+		return Current::read('Page.full_permalink') === (string)$page['Page']['full_permalink'];
 	}
 
 /**
@@ -391,7 +391,6 @@ class MenuHelper extends AppHelper {
 		if ($page['Page']['root_id'] === Page::PUBLIC_ROOT_PAGE_ID) {
 			$indent--;
 		}
-
 		return $indent;
 	}
 


### PR DESCRIPTION
メニューのアクティブ表示を判断するロジックがページの「Slug」だけを見ているため、
別空間（または別ルーム）に同じSlugが存在した場合、誤って複数個所をアクティブ表示してしまう。
アクティブなページであるかどうかはfull_permalinkで比較するように変更している
