### PR TITLE
アクティブなページをfull_permalinkで判断でなく、page_idで行うように修正。

### DIFF
--- a/View/Helper/MenuHelper.php
+++ b/View/Helper/MenuHelper.php
@@ -319,7 +319,7 @@ class MenuHelper extends AppHelper {
  * @return bool
  */
 	public function isActive($page) {
-		return Current::read('Page.full_permalink') === (string)$page['Page']['full_permalink'];
+		return Current::read('Page.id') === (string)$page['Page']['id'];
 	}
 
 /**


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/1468